### PR TITLE
Update logger in loop_over_hashes_and_remove_duplicates() function to…

### DIFF
--- a/etl/utils.py
+++ b/etl/utils.py
@@ -245,6 +245,6 @@ def loop_over_hashes_and_remove_duplicates(con, index_name,
                 deleted_documents += 1
 
     if deleted_documents > 0:
-        logger.info(f'----- {deleted_documents} from {index_name} index -----')
+        logger.info(f'----- {deleted_documents} deleted duplicated documents from {index_name} index -----')
     else:
         logger.info('----- There is no duplicated documents -----')


### PR DESCRIPTION
I discovered in my last ETL session logs that deleted duplicated documents are displayed on  like that : 

- ----- 15 from books index -----

That is not really intuitive 

So I have updated logger message like that : 

f'----- {deleted_documents} deleted duplicated documents from {index_name} index -----'