### PR TITLE
Remove Kibana from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,18 +19,6 @@ services:
       timeout: 10s
       retries: 5
 
-  kibana:
-    container_name: kb-container
-    image: docker.elastic.co/kibana/kibana:8.1.2
-    environment:
-      - ELASTICSEARCH_HOSTS=http://es-container:9200
-    networks:
-      - backend
-    depends_on:
-      - elasticsearch
-    ports:
-      - 5601:5601
-
   etl:
     container_name: etl-container
     build: ./etl
@@ -59,7 +47,6 @@ services:
       elasticsearch:
         condition: "service_healthy"
 
-
   dash:
     container_name: dash-container
     build: ./dash
@@ -71,8 +58,6 @@ services:
       - api
     ports:
       - 8050:8050    
-
-      
 
 volumes:
   data:


### PR DESCRIPTION
Kibana is no longer used on the project. Purpose of this Pull Request is to remove the service from `docker-compose.yml`