### PR TITLE
Add analyzer on summary_short field

### DIFF
--- a/etl/constants.py
+++ b/etl/constants.py
@@ -309,7 +309,15 @@ MOVIES_MAPPING = {
         },
         "opening_date": {"type": "date", "format": "yyyy-MM-dd"},
         "publication_date": {"type": "date", "format": "yyyy-MM-dd"},
-        "summary_short": {"type": "text"}
+        "summary_short":  {
+                            'type': 'text',
+                            'analyzer': 'english',
+                            'fields': {
+                                'keyword': {
+                                                "type": "keyword"
+                                            }
+                                }
+                        },
     }
 }
 


### PR DESCRIPTION
Update mapping to add an analyzer on movie's mapping `summary_short` field

Previously:

`"summary_sort": { "type": "text"}`

now:

```
"summary_short":  {
                            'type': 'text',
                            'analyzer': 'english',
                            'fields': {
                                'keyword': {
                                                "type": "keyword"
                                            }
                                }
                        },
```
