### PR TITLE
Fix env variable decalration

### DIFF
--- a/dag/etl_dag.py
+++ b/dag/etl_dag.py
@@ -14,6 +14,8 @@ from airflow import DAG
 SLACK_CONN_ID = 'slack'
 MOUNT_PATH = Variable.get('local_logs')
 NETWORK_ID = Variable.get('network_id')
+APY_KEY = Variable.get('api_key')
+
 
 def convert_datetime(datetime_string):
 
@@ -106,6 +108,7 @@ elastic_healthcheck = DockerOperator(
 
 run_etl = DockerOperator(
     image='cedricsoares/ny_times-etl:1.0.0',
+    environment={'API_KEY': API_KEY},
     mounts=[
         Mount(
             source=MOUNT_PATH,

--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11
+ENV API_KEY
 WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . /app
-COPY .env /app/.env
 RUN chmod +x start.sh
 CMD ["bash", "start.sh"]


### PR DESCRIPTION
On Github or in production environment no .env file if available. 
ENV variable mechanism replaced in project:
- In etl/Dockerfile: API_KEY ENV variable is created with no value
- in dag/etl_dag.py: API_KEY is imported from Airflow variables and used in `environment`  parameter in DockerOperator