### PR TITLE
Fix no env file in CI

### DIFF
--- a/dag/etl_dag.py
+++ b/dag/etl_dag.py
@@ -14,6 +14,8 @@ from airflow import DAG
 SLACK_CONN_ID = 'slack'
 MOUNT_PATH = Variable.get('local_logs')
 NETWORK_ID = Variable.get('network_id')
+APY_KEY = Variable.get('api_key')
+
 
 def convert_datetime(datetime_string):
 
@@ -106,6 +108,7 @@ elastic_healthcheck = DockerOperator(
 
 run_etl = DockerOperator(
     image='cedricsoares/ny_times-etl:1.0.0',
+    environment={'API_KEY': API_KEY},
     mounts=[
         Mount(
             source=MOUNT_PATH,

--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11
+ENV API_KEY
 WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . /app
-COPY .env /app/.env
 RUN chmod +x start.sh
 CMD ["bash", "start.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,34 +1,14 @@
-altgraph @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/altgraph-0.17.2-py2.py3-none-any.whl
-ansi2html==1.8.0
-certifi==2023.7.22
-charset-normalizer==3.2.0
-click==8.1.6
-dash==2.11.1
-dash-core-components==2.0.0
-dash-html-components==2.0.0
-dash-table==5.0.0
-Flask==2.2.5
-future @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/future-0.18.2-py3-none-any.whl
-idna==3.4
-importlib-metadata==6.8.0
-itsdangerous==2.1.2
-Jinja2==3.1.2
-macholib @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/macholib-1.15.2-py2.py3-none-any.whl
-MarkupSafe==2.1.3
-nest-asyncio==1.5.6
-numpy==1.25.1
-packaging==23.1
+apache-airflow==2.6.3
+docker_py==1.10.6
+elasticsearch==8.8.0
+fastapi==0.100.1
+fire==0.5.0
 pandas==2.0.3
 passlib==1.7.4
+pendulum==2.1.2
 plotly==5.15.0
-python-dateutil==2.8.2
+pydantic
+python-dotenv==1.0.0
 pytz==2023.3
-requests==2.31.0
-retrying==1.3.4
-six @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/six-1.15.0-py2.py3-none-any.whl
-tenacity==8.2.2
-typing_extensions==4.7.1
-tzdata==2023.3
-urllib3==2.0.4
-Werkzeug==2.2.3
-zipp==3.16.2
+Requests==2.31.0
+dash==2.11.1


### PR DESCRIPTION
CI failed in building docker image due to copy of a local .env file in etl/Dockerfile. 

Purpose of the fix is to replace env variable mechanism