### PR TITLE
Replace cedricsoares/ny_times-etl:1.0.0 by cedricsoares/ny_times-etl (latest) image version

### DIFF
--- a/dag/etl_dag.py
+++ b/dag/etl_dag.py
@@ -14,7 +14,7 @@ from airflow import DAG
 SLACK_CONN_ID = 'slack'
 MOUNT_PATH = Variable.get('local_logs')
 NETWORK_ID = Variable.get('network_id')
-APY_KEY = Variable.get('api_key')
+API_KEY = Variable.get('api_key')
 
 
 def convert_datetime(datetime_string):
@@ -107,7 +107,7 @@ elastic_healthcheck = DockerOperator(
 
 
 run_etl = DockerOperator(
-    image='cedricsoares/ny_times-etl:1.0.0',
+    image='cedricsoares/ny_times-etl',
     environment={'API_KEY': API_KEY},
     mounts=[
         Mount(


### PR DESCRIPTION
Due to the fact that CI pushes the latest ETL image version to docker hub, image version is now set with no tag version in Airflow DAG.

It means that Docker API downloads latest version in Airflow DAG.
